### PR TITLE
fixes for some docker tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:latest
 
+# set timezone
+RUN rm /etc/localtime
+RUN ln -s /usr/share/zoneinfo/Europe/Moscow /etc/localtime
+
 # Create work & result dirs
 RUN mkdir -p /clickhouse
 RUN mkdir -p /clickhouse/result
@@ -20,6 +24,9 @@ RUN pip install termcolor
 # Install dependencies required by test scripts
 RUN yum install -y perl
 RUN yum install -y sudo
+RUN yum install -y telnet
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-7
 
 # Install main script
 COPY /runscript.sh /clickhouse/

--- a/builder
+++ b/builder
@@ -216,6 +216,7 @@ function install_clickhouse_test_deps()
 
 	# Install dependencies required by test scripts to be run by clickhouse-test
 	sudo yum install -y perl
+	sudo yum install -y telnet
 }
 
 ##
@@ -530,7 +531,7 @@ function run_test_docker()
 
 	banner "Running Docker image ${IMAGE_NAME}"
 	#sudo docker run -it --mount src="$(pwd)",target=/clickhouse/result,type=bind $IMAGE_NAME
-	sudo docker run --mount src="$TMP_DIR",target=/clickhouse/result,type=bind $IMAGE_NAME
+	sudo docker run --mount src="$TMP_DIR",target=/clickhouse/result,type=bind -e CH_TEST_NAMES="$CH_TEST_NAMES" $IMAGE_NAME
 
 	cd $CWD_DIR
 	

--- a/runscript.sh
+++ b/runscript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 /usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml 2>/dev/null &
-/usr/bin/clickhouse-test > /clickhouse/result/out.txt
+/usr/bin/clickhouse-test "$CH_TEST_NAMES" > /clickhouse/result/out.txt
 echo $? > /clickhouse/result/out.code.txt
 


### PR DESCRIPTION
I fixed some tests that were failing on my platform because of missing packages and of the timezone that was not set to Moscow.

I've added a CH_TEST_NAMES environment variable that allows me to run only some tests. I use it with this regexp: 

CH_TEST_NAMES='^(?!00700_decimal_math).*$'

because I noticed that this test produces slightly different result from what is expected. I guess the floating point computation is different on my platform (different rounding), not sure why.

Nevertheless, I still also have test 00281_compile_sizeof_packed which fails but it is ok if I run it twice (??). And I also have these failing tests at the end of compilation that I haven't looked at:

10/11 Test #10: GLIBC_required_version .................***Failed    0.72 sec
11/11 Test #11: with_server ............................***Failed  337.48 sec
