### PR TITLE
Improvements to simplify building RPMs from Jenkins

### DIFF
--- a/Builder_Dockerfile
+++ b/Builder_Dockerfile
@@ -1,0 +1,12 @@
+# Base image used to build clickhouse-rpm, used to simplify and speedup builds in CI
+
+ARG BUILDER_BASE_IMAGE=centos:7
+FROM ${BUILDER_BASE_IMAGE}
+
+RUN yum -y install sudo
+
+COPY . clickhouse-rpm
+
+RUN cd clickhouse-rpm \
+    && ./builder install --deps \
+    && cd ..  && rm -rf clickhouse-rpm

--- a/builder
+++ b/builder
@@ -485,7 +485,10 @@ function setup_local_build()
 	# Extract everything before the first '-' in extracted git tag
 	VER=$(echo $GIT_TAG | awk 'BEGIN {FS="-"}{print $1}')
 
-	if [ "v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" == "${VER}" ]; then
+	if [ "${FLAG_NO_VERSION_CHECK}" ]; then
+		# Do not validate version, e.g. for master or PR builds.
+		echo "Version: v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-${TAG}"
+	elif [ "v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" == "${VER}" ]; then
 		# Version looks good
 		echo "Version parsed: v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-${TAG}"
 	else
@@ -605,7 +608,7 @@ function usage()
 	echo "./builder build --spec"
 	echo "		just create SPEC file"
 	echo "		do not download sources, do not build RPMs"
-	echo "./builder build --rpms [--debuginfo=no] [--cmake-build-type=Debug] [--test] "
+	echo "./builder build --rpms [--debuginfo=no] [--cmake-build-type=Debug] [--test] [--no-version-check]"
 	echo "		download sources, build SPEC file, build RPMs"
 	echo "		do not install dependencies"
 	echo "./builder build --download-sources"
@@ -687,6 +690,7 @@ FLAG_PUBLISH=''
 FLAG_PACKAGECLOUD=''
 FLAG_DELETE=''
 FLAG_DOWNLOAD=''
+FLAG_NO_VERSION_CHECK=''
 
 OPTIONS=$(getopt -o ''  --longoptions \
 test,\
@@ -708,7 +712,8 @@ local-sql,\
 publish,\
 packagecloud:,\
 delete,\
-download\
+download,\
+no-version-check\
 	-- "$@")
 
 #echo "OPTIONS=$OPTIONS"
@@ -805,6 +810,9 @@ while true; do
 			echo "Possible values: Debug Release RelWithDebugInfo MinSizeRel"
 			exit 1
 		fi
+		;;
+	--no-version-check)
+		FLAG_NO_VERSION_CHECK='yes'
 		;;
 	--docker)
 		FLAG_DOCKER='yes'


### PR DESCRIPTION
* Added `--no-version-check` flag to `build` command that suppresses
  version-from-tag vs version-from-source checks, allowing to build from
  master, PR or any other untagged commit.
* Added a Builder_Dockerfile which builds an image that can build rpms.